### PR TITLE
-sameq is deprecated

### DIFF
--- a/gopro
+++ b/gopro
@@ -15,7 +15,7 @@ function superview() {
     for i in *.MP4;
         do name=`echo $i | cut -d'.' -f1`+S;
         echo $name;
-        ffmpeg -i $i -sameq -vcodec mpeg4 -acodec ac3 -aspect 16:9 -strict experimental $name.MP4
+        ffmpeg -i $i -q:a 1 -q:v 1 -vcodec mpeg4 -acodec ac3 -aspect 16:9 -strict experimental $name.MP4
     done
 }
 
@@ -31,17 +31,17 @@ function convert(){
 for i in *.MP4;
     do name=`echo $i | cut -d'.' -f1`;
     echo $name;
-    ffmpeg -i $i -sameq -vcodec mpeg4 $name.mov;
+    ffmpeg -i $i -q:a 1 -q:v 1 -vcodec mpeg4 $name.mov;
 done
 }
 
 function slowmo(){
-    ffmpeg -i $1 -r 25 -vf "setpts=(9.6/1)*PTS" -sameq -vcodec libx264 $2
+    ffmpeg -i $1 -r 25 -vf "setpts=(9.6/1)*PTS" -q:a 1 -q:v 1 -vcodec libx264 $2
     echo "Video slowed down, use trim to trim the video"
 }
 
 function trim(){
-    ffmpeg -i $1 -ss $3 -t $4 -sameq -vcodec libx264 $2
+    ffmpeg -i $1 -ss $3 -t $4 -q:a 1 -q:v 1 -vcodec libx264 $2
 }
 
 function sort(){


### PR DESCRIPTION
The flag `-sameq` is not available in newer versions of ffmpeg.
You could use `-qscale 1` but this is ambiguous, the separate audio and video quality scalings are clearer.